### PR TITLE
Remove qq.h include that caused build failure

### DIFF
--- a/Yesod/Auth/Kerberos.hs
+++ b/Yesod/Auth/Kerberos.hs
@@ -25,8 +25,6 @@ module Yesod.Auth.Kerberos
       defaultKerberosConfig
     ) where
 
-#include "qq.h"
-
 import Yesod.Auth
 import Yesod.Auth.Message
 import Web.Authenticate.Kerberos


### PR DESCRIPTION
Previous commit removed `qq.h` file, this commit removes the `#include` directive.
